### PR TITLE
Move react-scripts to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "4.0.3",
     "react-webcam": "^5.2.4",
     "three": "^0.131.3",
     "web-vitals": "^1.0.1"
@@ -46,6 +45,7 @@
     ]
   },
   "devDependencies": {
-    "eslint-config-google": "^0.14.0"
+    "eslint-config-google": "^0.14.0",
+    "react-scripts": "4.0.3"
   }
 }


### PR DESCRIPTION
This is to work around a [security vulnerable](https://github.com/aha-001/react-tfjs-models/security/dependabot/yarn.lock/immer/open) introduced by react-scripts. Currently there is no fix to [react-scripts](https://www.npmjs.com/package/react-scripts) to upgrade its traversal dependency.

react-scripts are just used to run npm / yarn commands. They are not needed in runtime.